### PR TITLE
Support Marp core's basic features

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format:check": "lerna run --parallel format -- -l",
     "lint": "lerna run lint",
     "test": "lerna run test",
-    "watch": "lerna exec --parallel -- \"yarn watch < $(tty)\""
+    "watch": "lerna run --parallel watch"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.49",

--- a/packages/marp/.eslintrc.yml
+++ b/packages/marp/.eslintrc.yml
@@ -1,0 +1,3 @@
+rules:
+  class-methods-use-this: off
+  no-param-reassign: off

--- a/packages/marp/package.json
+++ b/packages/marp/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^8.5.2",
+    "cheerio": "^1.0.0-rc.2",
     "github-markdown-css": "^2.10.0",
     "node-sass": "^4.9.0",
     "rollup": "^0.59.4",

--- a/packages/marp/package.json
+++ b/packages/marp/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@marp-team/marpit": "^0.0.6",
-    "highlight.js": "^9.12.0"
+    "highlight.js": "^9.12.0",
+    "markdown-it-emoji": "^1.4.0"
   }
 }

--- a/packages/marp/package.json
+++ b/packages/marp/package.json
@@ -32,6 +32,7 @@
     "rollup-plugin-postcss": "^1.6.2"
   },
   "dependencies": {
-    "@marp-team/marpit": "^0.0.6"
+    "@marp-team/marpit": "^0.0.6",
+    "highlight.js": "^9.12.0"
   }
 }

--- a/packages/marp/package.json
+++ b/packages/marp/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --ignore-path ../../.prettierignore \"**/*.{md,json,css,scss}\"",
     "lint": "eslint --ignore-path ../../.eslintignore . && stylelint \"./**/*.{css,scss}\"",
     "test": "yarn --silent build --silent && cross-env NODE_ENV=test mocha --opts ../../mocha.opts",
-    "watch": "rollup -w -c"
+    "watch": "node ../../rollup_watch.js"
   },
   "devDependencies": {
     "autoprefixer": "^8.5.2",

--- a/packages/marp/rollup.config.js
+++ b/packages/marp/rollup.config.js
@@ -6,7 +6,7 @@ import pkg from './package.json'
 
 export default [
   {
-    external: ['@marp-team/marpit'],
+    external: ['@marp-team/marpit', 'highlight.js'],
     input: `src/${path.basename(pkg.main)}`,
     output: {
       name: 'marp',

--- a/packages/marp/src/marp.js
+++ b/packages/marp/src/marp.js
@@ -5,14 +5,21 @@ import Default from '../themes/default.scss'
 import Gaia from '../themes/gaia.scss'
 
 export default class Marp extends Marpit {
-  constructor(...args) {
-    super(...args)
+  constructor(opts) {
+    super({
+      markdown: [
+        'commonmark',
+        {
+          breaks: true,
+          highlight: (...hargs) => this.highlighter(...hargs),
+          linkify: true,
+        },
+      ],
+      ...opts,
+    })
 
     // Enable table
-    this.markdown.enable('table')
-    this.markdown.set({
-      highlight: (code, lang) => this.highlighter(code, lang),
-    })
+    this.markdown.enable(['table', 'linkify'])
 
     // Add themes
     this.themeSet.default = this.themeSet.add(Default)

--- a/packages/marp/src/marp.js
+++ b/packages/marp/src/marp.js
@@ -1,6 +1,6 @@
-/* eslint class-methods-use-this: 0 */
 import Marpit from '@marp-team/marpit'
 import highlightjs from 'highlight.js'
+import markdownItEmoji from 'markdown-it-emoji'
 import Default from '../themes/default.scss'
 import Gaia from '../themes/gaia.scss'
 
@@ -24,6 +24,15 @@ export default class Marp extends Marpit {
     // Add themes
     this.themeSet.default = this.themeSet.add(Default)
     this.themeSet.add(Gaia)
+  }
+
+  applyMarkdownItPlugins(md = this.markdown) {
+    super.applyMarkdownItPlugins(md)
+
+    // Emoji shorthand
+    md.use(markdownItEmoji, { shortcuts: {} })
+    md.renderer.rules.emoji = (token, idx) =>
+      `<span data-marpit-emoji>${token[idx].content}</span>`
   }
 
   highlighter(code, lang) {

--- a/packages/marp/src/marp.js
+++ b/packages/marp/src/marp.js
@@ -1,4 +1,6 @@
+/* eslint class-methods-use-this: 0 */
 import Marpit from '@marp-team/marpit'
+import highlightjs from 'highlight.js'
 import Default from '../themes/default.scss'
 import Gaia from '../themes/gaia.scss'
 
@@ -6,11 +8,24 @@ export default class Marp extends Marpit {
   constructor(...args) {
     super(...args)
 
+    // Enable table
     this.markdown.enable('table')
+    this.markdown.set({
+      highlight: (code, lang) => this.highlighter(code, lang),
+    })
 
-    const defaultTheme = this.themeSet.add(Default)
-    this.themeSet.default = defaultTheme
-
+    // Add themes
+    this.themeSet.default = this.themeSet.add(Default)
     this.themeSet.add(Gaia)
+  }
+
+  highlighter(code, lang) {
+    if (lang) {
+      if (['text', 'plain'].includes(lang)) return ''
+      if (highlightjs.getLanguage(lang))
+        return highlightjs.highlight(lang, code, true).value
+    }
+
+    return highlightjs.highlightAuto(code).value
   }
 }

--- a/packages/marp/src/marp.js
+++ b/packages/marp/src/marp.js
@@ -6,6 +6,8 @@ export default class Marp extends Marpit {
   constructor(...args) {
     super(...args)
 
+    this.markdown.enable('table')
+
     const defaultTheme = this.themeSet.add(Default)
     this.themeSet.default = defaultTheme
 

--- a/packages/marp/test/marp.js
+++ b/packages/marp/test/marp.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import cheerio from 'cheerio'
 import Marpit from '@marp-team/marpit'
 import Marp from '../lib/marp'
 
@@ -8,26 +9,22 @@ describe('Marp', () => {
   describe('markdown property', () => {
     const { markdown } = new Marp()
 
-    // TODO: Use cheerio to be disambiguation
-    it('renders breaks as <br> element', () =>
-      assert(
-        markdown
-          .render('hard\nbreak')
-          .replace(/\n/g, '')
-          .includes('hard<br />break')
-      ))
+    it('renders breaks as <br> element', () => {
+      const $ = cheerio.load(markdown.render('hard\nbreak'))
+      assert($('br').length === 1)
+    })
 
-    it('has enabled table syntax', () =>
-      assert(markdown.render('|a|b|\n|-|-|\n|c|d|').includes('<table>')))
+    it('has enabled table syntax', () => {
+      const $ = cheerio.load(markdown.render('|a|b|\n|-|-|\n|c|d|'))
+      assert($('table > thead > tr > th').length === 2)
+      assert($('table > tbody > tr > td').length === 2)
+    })
 
-    it('converts URL to hyperlink', () =>
-      assert(
-        markdown
-          .render('https://www.google.com/')
-          .includes(
-            '<a href="https://www.google.com/">https://www.google.com/</a>'
-          )
-      ))
+    it('converts URL to hyperlink', () => {
+      const address = 'https://www.google.com/'
+      const $ = cheerio.load(markdown.render(address))
+      assert($(`a[href="${address}"]`).text() === address)
+    })
   })
 
   describe('themeSet property', () => {

--- a/packages/marp/test/marp.js
+++ b/packages/marp/test/marp.js
@@ -5,6 +5,31 @@ import Marp from '../lib/marp'
 describe('Marp', () => {
   it('extends Marpit', () => assert(new Marp() instanceof Marpit))
 
+  describe('markdown property', () => {
+    const { markdown } = new Marp()
+
+    // TODO: Use cheerio to be disambiguation
+    it('renders breaks as <br> element', () =>
+      assert(
+        markdown
+          .render('hard\nbreak')
+          .replace(/\n/g, '')
+          .includes('hard<br />break')
+      ))
+
+    it('has enabled table syntax', () =>
+      assert(markdown.render('|a|b|\n|-|-|\n|c|d|').includes('<table>')))
+
+    it('converts URL to hyperlink', () =>
+      assert(
+        markdown
+          .render('https://www.google.com/')
+          .includes(
+            '<a href="https://www.google.com/">https://www.google.com/</a>'
+          )
+      ))
+  })
+
   describe('themeSet property', () => {
     const { themeSet } = new Marp()
 

--- a/packages/marp/test/marp.js
+++ b/packages/marp/test/marp.js
@@ -25,6 +25,14 @@ describe('Marp', () => {
       const $ = cheerio.load(marp().markdown.render(address))
       assert($(`a[href="${address}"]`).text() === address)
     })
+
+    it('converts emoji shorthand to unicode emoji', () => {
+      const $ = cheerio.load(
+        marp().markdown.render('# emoji:heart:\n\n## emoji❤️')
+      )
+      assert($('h1').html() === $('h2').html())
+      assert($('h1 > span[data-marpit-emoji]').length === 1)
+    })
   })
 
   describe('themeSet property', () => {

--- a/packages/marp/test/marp.js
+++ b/packages/marp/test/marp.js
@@ -4,33 +4,80 @@ import Marpit from '@marp-team/marpit'
 import Marp from '../lib/marp'
 
 describe('Marp', () => {
+  const marp = () => new Marp()
+
   it('extends Marpit', () => assert(new Marp() instanceof Marpit))
 
   describe('markdown property', () => {
-    const { markdown } = new Marp()
-
     it('renders breaks as <br> element', () => {
-      const $ = cheerio.load(markdown.render('hard\nbreak'))
+      const $ = cheerio.load(marp().markdown.render('hard\nbreak'))
       assert($('br').length === 1)
     })
 
     it('has enabled table syntax', () => {
-      const $ = cheerio.load(markdown.render('|a|b|\n|-|-|\n|c|d|'))
+      const $ = cheerio.load(marp().markdown.render('|a|b|\n|-|-|\n|c|d|'))
       assert($('table > thead > tr > th').length === 2)
       assert($('table > tbody > tr > td').length === 2)
     })
 
     it('converts URL to hyperlink', () => {
       const address = 'https://www.google.com/'
-      const $ = cheerio.load(markdown.render(address))
+      const $ = cheerio.load(marp().markdown.render(address))
       assert($(`a[href="${address}"]`).text() === address)
     })
   })
 
   describe('themeSet property', () => {
-    const { themeSet } = new Marp()
+    const { themeSet } = marp()
 
     it('has default theme', () =>
       assert(themeSet.default === themeSet.get('default')))
+  })
+
+  describe('#highlighter', () => {
+    context('when fence is rendered without lang', () => {
+      const $ = cheerio.load(marp().markdown.render('```\n# test\n```'))
+
+      it('highlights code automatically', () =>
+        assert($('code > [class^="hljs-"]').length > 0))
+    })
+
+    context('when fence is rendered with specified lang', () => {
+      const $ = cheerio.load(marp().markdown.render('```markdown\n# test\n```'))
+
+      it('highlights code with specified lang', () => {
+        assert($('code.language-markdown').length === 1)
+        assert($('code > .hljs-section').length === 1)
+      })
+    })
+
+    const plainLangs = ['text', 'plain']
+
+    plainLangs.forEach(lang => {
+      context(`when fence is rendered with ${lang} lang`, () => {
+        const $ = cheerio.load(
+          marp().markdown.render(`\`\`\`${lang}\n# test\n\`\`\``)
+        )
+
+        it('disables highlight', () =>
+          assert($('code > [class^="hljs-"]').length === 0))
+      })
+    })
+
+    context('with overriden #highlighter', () => {
+      const instance = marp()
+
+      instance.highlighter = (code, lang) => {
+        assert(code.trim() === 'test')
+        assert(lang === 'markdown')
+
+        return '<b class="customized">customized</b>'
+      }
+
+      const $ = cheerio.load(instance.markdown.render('```markdown\ntest\n```'))
+
+      it('highlights with custom highlighter', () =>
+        assert($('code > .customized').length === 1))
+    })
   })
 })

--- a/packages/marp/themes/default.scss
+++ b/packages/marp/themes/default.scss
@@ -1,10 +1,11 @@
 /**
- * [WIP] Marp default theme.
+ * [WIP] Default theme
  *
  * @theme default
  */
 
 @import '~github-markdown-css';
+@import '~highlight.js/styles/github';
 
 section {
   @extend .markdown-body;

--- a/packages/marp/themes/gaia.scss
+++ b/packages/marp/themes/gaia.scss
@@ -4,7 +4,8 @@
  * @theme gaia
  */
 
-@import url(https://fonts.googleapis.com/css?family=Lato:400,900);
+@import url('https://fonts.googleapis.com/css?family=Lato:400,900');
+@import '~highlight.js/styles/sunburst';
 
 $color-primary: #0288d1;
 

--- a/packages/marp/themes/gaia.scss
+++ b/packages/marp/themes/gaia.scss
@@ -12,7 +12,6 @@ $color-primary: #0288d1;
 section {
   padding: 80px;
   color: #455a64;
-
   background-color: #fff8e1;
   background-image: linear-gradient(
     135deg,
@@ -21,7 +20,6 @@ section {
     rgba(#fff, 0) 50%,
     rgba(#fff, 0.05)
   );
-
   font-size: 35px;
   font-family: 'Lato', 'Avenir Next', 'Avenir', 'Trebuchet MS', 'Segoe UI',
     sans-serif;

--- a/rollup_watch.js
+++ b/rollup_watch.js
@@ -1,0 +1,11 @@
+/**
+ * Watch process helper for rollup
+ * @see https://github.com/rollup/rollup/issues/1919
+ */
+
+const childProcess = require('child_process')
+
+childProcess.spawn('yarn', ['rollup', '-w', '-c'], {
+  shell: true,
+  stdio: ['pipe', process.stdout, process.stderr],
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,6 +946,10 @@ bluebird@^3.1.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1192,6 +1196,17 @@ character-reference-invalid@^1.0.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^2.0.3:
   version "2.0.3"
@@ -1666,6 +1681,15 @@ css-modules-loader-core@^1.1.0:
     postcss-modules-scope "1.1.0"
     postcss-modules-values "1.3.0"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-selector-tokenizer@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz#e6988474ae8c953477bf5e7efecfceccd9cf4c86"
@@ -1673,6 +1697,10 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -1883,7 +1911,7 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -1902,6 +1930,13 @@ domhandler@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
   dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1:
@@ -2832,7 +2867,7 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-htmlparser2@^3.9.2:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -3561,7 +3596,7 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.17.5, lodash@^4.2.0:
+lodash@^4.15.0, lodash@^4.17.5, lodash@^4.2.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4037,6 +4072,12 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -4220,6 +4261,12 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 pascalcase@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,6 +3670,10 @@ markdown-escapes@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
 
+markdown-it-emoji@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
+
 markdown-it-front-matter@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz#e50bf56e77e6a4f5ac4ffa894d4d45ccd9896b20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,6 +2804,10 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+highlight.js@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"


### PR DESCRIPTION
This PR will implement the basic features of Marp core.

[Marpit](https://github.com/marp-team/marpit) framework has a minimum support to render a slide deck through Marpit Markdown, but we have to extend to support more powerful features in Marp core.

At first, we aim to implement the basic features of pre-released Marp. In future, Marp core is going to support advanced features that cannot static rendering by Marpit.

Currently we are not thinking to keep a complete compatibility with pre-released Marp. We may drop a few features for optimizing to a web presentation. (Of course it may be resurrected in future)

### Implemented

- [x] Enable GFM table
- [x] Enable URL autolink
- [x] Code highlighting by highlight.js
  - [x] Add color scheme styling to theme
- [x] Convert emoji shorthand to unicode emoji by markdown-it-emoji

### Difference from pre-released Marp

- Currently we are not including Twemoji. The shorthand text might become a way to show high-resolution SVG emoji without dependency to OS, but we treat as same as unicode emoji now.
- The syntax of `<mark>` element (`==mark==`) is not supporting now.
- Math typesetting support will implement in another PR. We might try MathJax instead of KaTeX for better syntax support. We would decide which to use by considering overall.