### PR TITLE
Fix error of parcel build on Netlify

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    'postcss-import': true,
     autoprefixer: true,
   },
 }

--- a/.sassrc.js
+++ b/.sassrc.js
@@ -1,0 +1,5 @@
+const path = require('path')
+
+module.exports = {
+  includePaths: [path.resolve(__dirname, './node_modules')],
+}

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/marp-team/marp"
   },
   "scripts": {
+    "build": "yarn run --silent clean && parcel build src/* --no-source-maps",
     "clean": "rimraf dist",
     "format": "prettier \"**/*.{css,js,json,md,scss,ts,yaml,yml}\"",
     "format:check": "yarn --silent format -l",
     "format:write": "yarn --silent format --write",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",
-    "parcel": "yarn run --silent clean && parcel build src/* --no-source-maps",
-    "watch": "parcel src/*"
+    "start": "parcel src/*"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "docsify-themeable": "^0.3.0",
     "node-sass": "^4.9.3",
     "parcel-bundler": "^1.9.7",
-    "postcss-import": "^11.1.0",
     "prettier": "^1.14.2",
     "pug": "^2.0.3",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -18,21 +18,20 @@
     "url": "https://github.com/marp-team/marp"
   },
   "scripts": {
-    "build": "yarn run --silent clean && parcel build src/*",
     "clean": "rimraf dist",
     "format": "prettier \"**/*.{css,js,json,md,scss,ts,yaml,yml}\"",
     "format:check": "yarn --silent format -l",
     "format:write": "yarn --silent format --write",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",
-    "start": "parcel src/*"
+    "parcel": "yarn run --silent clean && parcel build src/* --no-source-maps",
+    "watch": "parcel src/*"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.3",
     "docsify-themeable": "^0.3.0",
     "node-sass": "^4.9.3",
     "parcel-bundler": "^1.9.7",
-    "postcss": "^7.0.2",
-    "postcss-import": "^12.0.0",
+    "postcss-import": "^11.1.0",
     "prettier": "^1.14.2",
     "pug": "^2.0.3",
     "rimraf": "^2.6.2",

--- a/src/docsify.scss
+++ b/src/docsify.scss
@@ -1,2 +1,2 @@
-@import '~docsify-themeable/dist/css/theme-defaults.css';
+@import '~docsify-themeable/dist/css/theme-defaults';
 @import './docsify/layout';

--- a/src/index.pug
+++ b/src/index.pug
@@ -3,6 +3,6 @@ html
   head
     meta(charset="UTF-8")
     meta(name="robots", content="noindex,noarchive")
-    meta(http-equiv="refresh", content="0;URL=https://github.com/yhatt/marp/")
+    meta(http-equiv="refresh", content="0;URL=https://github.com/marp-team/marp/")
     title @marp-team/marp
   body

--- a/yarn.lock
+++ b/yarn.lock
@@ -4147,11 +4147,11 @@ postcss-html@^0.33.0:
   dependencies:
     htmlparser2 "^3.9.2"
 
-postcss-import@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-12.0.0.tgz#149f96a4ef0b27525c419784be8517ebd17e92c5"
+postcss-import@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-11.1.0.tgz#55c9362c9192994ec68865d224419df1db2981f0"
   dependencies:
-    postcss "^7.0.1"
+    postcss "^6.0.1"
     postcss-value-parser "^3.2.3"
     read-cache "^1.0.0"
     resolve "^1.1.7"
@@ -4564,7 +4564,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.19, postcss@^6.0.8:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.19, postcss@^6.0.8:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:
@@ -4572,7 +4572,7 @@ postcss@^6.0.0, postcss@^6.0.19, postcss@^6.0.8:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.2:
+postcss@^7.0.0, postcss@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.2.tgz#7b5a109de356804e27f95a960bef0e4d5bc9bb18"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,7 +4005,7 @@ physical-cpu-count@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz#18de2f97e4bf7a9551ad7511942b5496f7aba660"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -4146,15 +4146,6 @@ postcss-html@^0.33.0:
   resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.33.0.tgz#8ab6067d7a8a234e1937920b38760e3be1dca070"
   dependencies:
     htmlparser2 "^3.9.2"
-
-postcss-import@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-11.1.0.tgz#55c9362c9192994ec68865d224419df1db2981f0"
-  dependencies:
-    postcss "^6.0.1"
-    postcss-value-parser "^3.2.3"
-    read-cache "^1.0.0"
-    resolve "^1.1.7"
 
 postcss-jsx@^0.33.0:
   version "0.33.0"
@@ -4564,7 +4555,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.19, postcss@^6.0.8:
+postcss@^6.0.0, postcss@^6.0.19, postcss@^6.0.8:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:
@@ -4837,12 +4828,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-cache@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
-  dependencies:
-    pify "^2.3.0"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -5111,7 +5096,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.1.5, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
We are going to host web and JS/CSS by Netlify. It will use in common branded document of Marp family.

Parcel build is working on local correctly, but isn't working on netlify. This PR is trying to resolve this.

```
10:47:45 PM: yarn run v1.9.4
10:47:45 PM: $ yarn run --silent clean && parcel build src/*
10:47:50 PM: Unknown error from PostCSS plugin. Your current PostCSS version is 6.0.23, but postcss-import uses 7.0.2. Perhaps this is the source of the error below.
10:47:50 PM: 🚨  /opt/build/repo/src/docsify.scss:undefined:undefined: Failed to find 'f7a5c2b88937640a559938331eccd348.css'
10:47:50 PM:   in [
10:47:50 PM:     /opt/build/repo/src
10:47:50 PM:   ]
10:47:50 PM:   in [
10:47:50 PM:     /opt/build/repo/src
10:47:50 PM:   ]
10:47:50 PM:     at resolveModule.catch.catch (/opt/build/repo/node_modules/postcss-import/lib/resolve-id.js:35:13)
10:47:50 PM:     at <anonymous>
10:47:51 PM: error Command failed with exit code 1.
10:47:51 PM: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```