### PR TITLE
Add contributing guideline for Marp projects

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,11 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident. Further details of
-specific enforcement policies may be posted separately.
+reported by contacting the project team at marp-team@marp.app. All complaints
+will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# CONTRIBUTING
+
+Thank you for taking the time to read how to contribute to our project! This is the basic guideline for contributing to [Marp team owned projects][marp-team].
+
+You can start contributing our project in several way like improve docs, report bug, request feature, writing code, and so on.
+
+Depending on the project you want to contribute, it might have additional guidelines you should follow at that repository. Please also check the guideline per repository.
+
+## [Code of conduct][code-of-conduct]
+
+We follow [Contributor Covenant Code of Conduct][code-of-conduct] in the all of repositories managed by [marp-team].
+
+## Question
+
+Keep in mind that **GitHub issue tracker is not a support forum.** _You should not expect answer to such a question at GitHub._
+
+You can use [StackOverflow](https://stackoverflow.com/) if you want.
+
+## Report issue
+
+At first, you should search similar issues before reporting your issue. It may have already been discussed or resolved in the other issue.
+
+[:mag: `org:marp-team is:issue [keyword]`](https://github.com/search?q=org%3Amarp-team+is%3Aissue+%5Bkeyword%5D) is useful to search issue from across our projects.
+
+<!-- TODO: Add guideline of the content of issue -->
+
+> :information_source: Several project is consisted by multiple packages created by [marp-team]. If you know which project causes an issue, please report issue to that repo.
+
+## Feature requests
+
+- Feature request gives feedback to our, but _it would not always implement_.
+- Each our packages always have just one core feature. The requested feature could be rejected if it's far from supporting the project core.
+- When there is a pull request implemented the brand new feature, the maintainer have to be careful to merge only the truly valuable features for project. If not, it just would trigger a scope creep.
+
+## Pull request
+
+<!-- TODO: Add guideline of the pull request -->
+
+[code-of-conduct]: https://github.com/marp-team/marp/blob/master/.github/CODE_OF_CONDUCT.md
+[marp-team]: https://github.com/marp-team/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,40 +1,65 @@
-# CONTRIBUTING
+# Contributing to Marp project
 
 Thank you for taking the time to read how to contribute to our project! This is the basic guideline for contributing to [Marp team owned projects][marp-team].
 
-You can start contributing our project in several way like improve docs, report bug, request feature, writing code, and so on.
+You can start contributing our project in several ways: improve docs, report bug, request feature, writing code, and so on.
 
 Depending on the project you want to contribute, it might have additional guidelines you should follow at that repository. Please also check the guideline per repository.
+
+> :beginner: Would you the first time to contribute OSS? [Open Source Guides](https://opensource.guide/how-to-contribute/) might help you.
 
 ## [Code of conduct][code-of-conduct]
 
 We follow [Contributor Covenant Code of Conduct][code-of-conduct] in the all of repositories managed by [marp-team].
 
-## Question
-
-Keep in mind that **GitHub issue tracker is not a support forum.** _You should not expect answer to such a question at GitHub._
-
-You can use [StackOverflow](https://stackoverflow.com/) if you want.
-
 ## Report issue
 
-At first, you should search similar issues before reporting your issue. It may have already been discussed or resolved in the other issue.
+At first, you should search for similar issues before reporting your issue. It may have already been discussed or resolved in the other issue.
 
 [:mag: `org:marp-team is:issue [keyword]`](https://github.com/search?q=org%3Amarp-team+is%3Aissue+%5Bkeyword%5D) is useful to search issue from across our projects.
 
-<!-- TODO: Add guideline of the content of issue -->
+If you could not find out similar issue, you can create new issue. Please not contain multiple reports in one issue. It should have only one theme.
 
-> :information_source: Several project is consisted by multiple packages created by [marp-team]. If you know which project causes an issue, please report issue to that repo.
+> :information_source: Some projects have consisted of multiple packages created by [marp-team]. If you know which project causes an issue, please report the issue to that repo.
 
-## Feature requests
+### Question
 
-- Feature request gives feedback to our, but _it would not always implement_.
-- Each our packages always have just one core feature. The requested feature could be rejected if it's far from supporting the project core.
-- When there is a pull request implemented the brand new feature, the maintainer have to be careful to merge only the truly valuable features for project. If not, it just would trigger a scope creep.
+Keep in mind that **GitHub issue tracker is not a support forum.** _You should not expect an answer to such a question at GitHub._ You can use [StackOverflow](https://stackoverflow.com/) if you want.
+
+### Feature request
+
+Feature request is welcome because it could give feedback to us.
+
+However, we have to take a moment to judge whether fitting to the project aim and scope. We require clear benefit and strong incentive to work for the request because each our projects should keep simple and smart. A created issue would serve as a table for discussion.
+
+### Bug report
+
+> :warning: Did you find a security vulnerability? _Report directly to security@marp.app instead of opening a new issue._
+
+Currently, we don't have a default issue template. But to assist in finding the bug by committer rapidly, it is good to describe these:
+
+- Expected behavior and actual behavior
+- Necessary steps and resources to reproduce bug
+- Occurred environment (e.g. the version of OS, browser, Node.js)
 
 ## Pull request
 
-<!-- TODO: Add guideline of the pull request -->
+You can submit pull request if you have fixed or added useful something to our projects.
+
+- **Indicate related issue(s) in description of PR.** In many cases, the created PR should already have related problems. GitHub can [close issue automatically by keyword](https://help.github.com/articles/closing-issues-using-keywords/).
+
+- **Keep code styling.** We are using [yarn] package manager, [Prettier] formatter, and linters for each language. CI build would fail when using the wrong format/style. It could fix by `yarn format --write` and `yarn lint:[lang] --fix` in most projects.
+
+- **Maintain tests.** We need to fill code coverage by writing meaningful tests. In many projects, we are setting a threshold of global line coverage to 95%. You could measure coverage in local by running `yarn test:coverage`.
+
+### For maintainer
+
+These are tasks for maintainer, and usually comitter doesn't have to worry.
+
+- If there is CHANGELOG.md in a working project, the maintainer has to update it after (or while) merge PR. We're adopting the format based on [Keep a Changelog].
 
 [code-of-conduct]: https://github.com/marp-team/marp/blob/master/.github/CODE_OF_CONDUCT.md
 [marp-team]: https://github.com/marp-team/
+[yarn]: https://yarnpkg.com/
+[prettier]: https://prettier.io/
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/


### PR DESCRIPTION
To allow GitHub issue tracker of Marp project repos, we add contributing guideline for Marp projects in this repo.

[yhatt/marp](https://github.com/yhatt/marp/issues) has happened a confusion caused by a lot of issues because it has no guidelines about issue management. I have not responded most issues/PRs to show stopping maintenance at the legacy languages. We should avoid it in marp-team.

We are going to allow issue tracking by refer to this guideline in per projects. [Marpit](https://github.com/marp-team/marpit) would become to the first project applied this guideline.