### PR TITLE
Remove index.html and redirect to repository by Netlify directly

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
 https://marp.netlify.com/* https://marp.app/:splat 301!
-/* /index.html 200
+/* https://github.com/marp-team/marp 302

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="robots" content="noindex,noarchive">
-    <meta http-equiv="refresh" content="0;URL=https://github.com/marp-team/marp/">
-    <title>Marp</title>
-</head>
-</html>


### PR DESCRIPTION
I'm trying to use the redirect setting provided by Netlify. HTML for redirect by meta may be unnecessary.