### PR TITLE
Update Marp family section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,60 @@
 
 ## Marp family
 
-|                       Name | Description                                                                                                                         | Release                                                                                                                    |
-| -------------------------: | :---------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
-|    [@marp-team/marp][marp] | 🚪 The entrance repository of Marp family. In future we would host website.                                                         |                                                                                                                            |
-|       **[Marpit][marpit]** | The skinny framework for creating slide deck from Markdown. ([marpit.marp.app])                                                     | [![@marp-team/marpit](https://img.shields.io/npm/v/@marp-team/marpit.svg?style=flat-square&logo=npm)][marpit-npm]          |
-| **[Marp Core][marp-core]** | The core of Marp converter based on [Marpit][marpit]. It has the practical Markdown syntax, advanced features, and official themes. | [![@marp-team/marp-core](https://img.shields.io/npm/v/@marp-team/marp-core.svg?style=flat-square&logo=npm)][marp-core-npm] |
-|   **[Marp CLI][marp-cli]** | A CLI interface for [Marp Core][marp-core] and any Marpit based framework. It can convert Markdown to static HTML / CSS and PDF.    | [![@marp-team/marp-cli](https://img.shields.io/npm/v/@marp-team/marp-cli.svg?style=flat-square&logo=npm)][marp-cli-npm]    |
-|   **[Marp Web][marp-web]** | The main interface of Marp. It can work on the both of online / offline by using [PWA].                                             | [![web.marp.app](https://bit.ly/2RF9Nzn)][marp-web-site]<br>_(tech&nbsp;demo)_                                             |
-|             _Marp Desktop_ | The desktop client of [Marp Web][marp-web-site] wrapped in [Electron]. It would replace [yhatt/marp], and support local files.      | _(PLANNED)_                                                                                                                |
+Our projects have consisted of manyrepos in order to focus limited scope per repository.
+
+This repo (**[@marp-team/marp][marp]**) is an entrance to Marp family. In the future, it will host [our website](https://marp.app/), and place project-wide utilities by the monorepo structure.
+
+### Framework / Core
+
+|                             Name | Description                                                                        | Release                                                   |
+| -------------------------------: | :--------------------------------------------------------------------------------- | :-------------------------------------------------------- |
+| **[Marpit]** ([marpit.marp.app]) | The skinny framework for creating slide deck from Markdown.                        | [![@marp-team/marpit][badge-marpit]][marpit-npm]          |
+|       **[Marp Core][marp-core]** | The core of Marp converter with practical features and [themes][marp-core-themes]. | [![@marp-team/marp-core][badge-marp-core]][marp-core-npm] |
+
+### Apps
+
+|                           Name | Description                                                                             | Release                                                     |
+| -----------------------------: | :-------------------------------------------------------------------------------------- | :---------------------------------------------------------- |
+|       **[Marp CLI][marp-cli]** | [Marp Core][marp-core] / [Marpit]'s CLI interface to convert into HTML, PDF, and image. | [![@marp-team/marp-cli][badge-marp-cli]][marp-cli-npm]      |
+|       **[Marp Web][marp-web]** | The main interface of Marp based on [PWA] and [Preact] framework.                       | [![tech demo][badge-marp-web]][marp-web-site]               |
+|                   Marp Desktop | The desktop client for [Marp Web][marp-web-site] for replacing [yhatt/marp].            | ![PLANNED][badge-planned]                                   |
+| **[Marp VSCode][marp-vscode]** | A [VS Code][vscode] extension to preview the slide deck written in Marp Markdown.       | [![VS Marketplace][badge-marp-vscode]][marp-vscode-release] |
+
+### Integrations
+
+|       Name | Description                          | Release                                            |
+| ---------: | :----------------------------------- | :------------------------------------------------- |
+| Marp React | Marp renderer component for [React]. | [![badge-wip]](https://kkryjmyy75.codesandbox.io/) |
+|   Marp Vue | Marp renderer component for [Vue].   | [![badge-wip]](https://2x994l3roj.codesandbox.io/) |
 
 [yhatt/marp]: https://github.com/yhatt/marp
 [marp]: https://github.com/marp-team/marp
 [marpit]: https://github.com/marp-team/marpit
 [marp-core]: https://github.com/marp-team/marp-core
+[marp-core-themes]: https://github.com/marp-team/marp-core/tree/master/themes
 [marp-cli]: https://github.com/marp-team/marp-cli
 [marp-web]: https://github.com/marp-team/marp-web
+[marp-vscode]: https://github.com/marp-team/marp-vscode
 [pwa]: https://en.wikipedia.org/wiki/Progressive_Web_Apps
+[preact]: https://preactjs.com/
 [electron]: https://electronjs.org/
+[vscode]: https://code.visualstudio.com/
+[react]: https://reactjs.org/
+[vue]: https://vuejs.org/
 [marpit.marp.app]: https://marpit.marp.app/
 [marpit-npm]: https://www.npmjs.com/package/@marp-team/marpit
 [marp-core-npm]: https://www.npmjs.com/package/@marp-team/marp-core
 [marp-cli-npm]: https://www.npmjs.com/package/@marp-team/marp-cli
 [marp-web-site]: https://web.marp.app/
+[marp-vscode-release]: https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode
+[badge-marpit]: https://img.shields.io/npm/v/@marp-team/marpit.svg?style=flat-square&logo=npm
+[badge-marp-core]: https://img.shields.io/npm/v/@marp-team/marp-core.svg?style=flat-square&logo=npm
+[badge-marp-cli]: https://img.shields.io/npm/v/@marp-team/marp-cli.svg?style=flat-square&logo=npm
+[badge-marp-web]: https://img.shields.io/badge/%E2%80%8B-tech%20demo-%230288d1.svg?style=flat-square&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAUUlEQVQokWNgGD6AqePif3Sx9B2PMcQwNKFrTN/x+D9ejTBNyBphmnBqRNYE04isCatGdE1MHRf/o2vC0IhNE1PaXPwacWnCqxGfJoI2Dn4AAN0ZrMM1VUFvAAAAAElFTkSuQmCC
+[badge-marp-vscode]: https://img.shields.io/visual-studio-marketplace/v/marp-team.marp-vscode.svg?style=flat-square&logo=visual-studio-code&label=Marketplace
+[badge-planned]: https://img.shields.io/badge/-PLANNED-lightgrey.svg?style=flat-square
+[badge-wip]: https://img.shields.io/badge/-Work%20in%20progress-lightgrey.svg?style=flat-square
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ This repo (**[@marp-team/marp][marp]**) is an entrance to Marp family. In the fu
 
 ### Apps
 
-|                           Name | Description                                                                             | Release                                                     |
-| -----------------------------: | :-------------------------------------------------------------------------------------- | :---------------------------------------------------------- |
-|       **[Marp CLI][marp-cli]** | [Marp Core][marp-core] / [Marpit]'s CLI interface to convert into HTML, PDF, and image. | [![@marp-team/marp-cli][badge-marp-cli]][marp-cli-npm]      |
-|       **[Marp Web][marp-web]** | The main interface of Marp based on [PWA] and [Preact] framework.                       | [![tech demo][badge-marp-web]][marp-web-site]               |
-|                   Marp Desktop | The desktop client for [Marp Web][marp-web-site] for replacing [yhatt/marp].            | ![PLANNED][badge-planned]                                   |
-| **[Marp VSCode][marp-vscode]** | A [VS Code][vscode] extension to preview the slide deck written in Marp Markdown.       | [![VS Marketplace][badge-marp-vscode]][marp-vscode-release] |
+|                     Name | Description                                                                             | Release                                                |
+| -----------------------: | :-------------------------------------------------------------------------------------- | :----------------------------------------------------- |
+| **[Marp CLI][marp-cli]** | [Marp Core][marp-core] / [Marpit]'s CLI interface to convert into HTML, PDF, and image. | [![@marp-team/marp-cli][badge-marp-cli]][marp-cli-npm] |
+| **[Marp Web][marp-web]** | The main interface of Marp based on [PWA] and [Preact] framework.                       | [![tech demo][badge-marp-web]][marp-web-site]          |
+|             Marp Desktop | The desktop client for [Marp Web][marp-web-site] for replacing [yhatt/marp].            | ![PLANNED][badge-planned]                              |
 
 ### Integrations
 
-|       Name | Description                          | Release                                            |
-| ---------: | :----------------------------------- | :------------------------------------------------- |
-| Marp React | Marp renderer component for [React]. | [![badge-wip]](https://kkryjmyy75.codesandbox.io/) |
-|   Marp Vue | Marp renderer component for [Vue].   | [![badge-wip]](https://2x994l3roj.codesandbox.io/) |
+|                           Name | Description                                                                       | Release                                                     |
+| -----------------------------: | :-------------------------------------------------------------------------------- | :---------------------------------------------------------- |
+| **[Marp VSCode][marp-vscode]** | A [VS Code][vscode] extension to preview the slide deck written in Marp Markdown. | [![VS Marketplace][badge-marp-vscode]][marp-vscode-release] |
+|                     Marp React | Marp renderer component for [React].                                              | [![badge-wip]](https://kkryjmyy75.codesandbox.io/)          |
+|                       Marp Vue | Marp renderer component for [Vue].                                                | [![badge-wip]](https://2x994l3roj.codesandbox.io/)          |
 
 [yhatt/marp]: https://github.com/yhatt/marp
 [marp]: https://github.com/marp-team/marp


### PR DESCRIPTION
Marp family section on `README.md` should be reorganized because of a lot of projects to support Marp ecosystem.

- Grouped our projects by the kind.
- I had released **[Marp for VS Code](https://github.com/marp-team/marp-vscode)**, the VS Code extension to preview Marp Markdown. **(NOTICE: available only in VSCode insiders)**

<p align="center"><a href="https://github.com/marp-team/marp-vscode"><img src="https://raw.githubusercontent.com/marp-team/marp-vscode/master/images/screenshot.png" width="500" /></a></p>

- Added components working in progress: [Marp React](https://codesandbox.io/s/kkryjmyy75) and [Marp Vue](https://2x994l3roj.codesandbox.io/). I'm trying these at my CodeSandbox.

|[Marp React example](https://codesandbox.io/s/kkryjmyy75)<br>([React 16.8: React Hooks](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html))|[Marp Vue example](https://2x994l3roj.codesandbox.io/)<br>([Vue 2.6 Macross](https://medium.com/the-vue-point/vue-2-6-released-66aa6c8e785e))|
|:---:|:---:|
|[![screenshot_2019-02-06 marp for react example](https://user-images.githubusercontent.com/3993388/52337969-7298ac00-2a4c-11e9-86f3-9d1c6f17f9d1.png)](https://codesandbox.io/s/kkryjmyy75)|[![screenshot_2019-02-06 marp for vue example](https://user-images.githubusercontent.com/3993388/52337978-7af0e700-2a4c-11e9-91a2-b60f27962e77.png)](https://2x994l3roj.codesandbox.io/)|
|Includes integration w/<br>[Spectacle](https://github.com/FormidableLabs/spectacle) & [mdx-deck](https://github.com/jxnblk/mdx-deck)|Includes integration w/<br>[vue-awesome-swiper](https://github.com/surmon-china/vue-awesome-swiper) & [Eagle.js](https://github.com/zulko/eagle.js/)|