### PR TITLE
Enable GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-# github: [yhatt]
-patreon: yhatt
+github: [yhatt]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ Managed by [@marp-team](https://github.com/marp-team).
 
 - <img src="https://github.com/yhatt.png" width="16" height="16"/> Yuki Hattori ([@yhatt](https://github.com/yhatt))
 
+<!-- ### Sponsors -->
+
+<!-- Name and icons (Top-tier sponsors)
+
+- [<img src="https://github.com/yhatt.png" width="32" height="32" valign="middle"/> Yuki Hattori](https://github.com/yhatt)
+
+-->
+
+<!-- Icons (Mid-tier sponsors)
+(And) we are supported by them!
+
+<p>
+  <a href="https://github.com/yhatt"><img src="https://github.com/yhatt.png" width="32" height="32" /></a>
+</p>
+-->
+
+<!-- Thanks for our sponsors! :heart: -->
+
 ## License
 
 [MIT License](LICENSE)


### PR DESCRIPTION
Today I become a member of GitHub Sponsors beta program! This PR updates `FUNDING.yml` and prepares "Sponsors" section to show thanks for sponsors.

https://github.com/users/yhatt/sponsorship

I'm already using Patreon (yhatt/marp#266), but I would advice patrons to move into GitHub Sponsors.