### PR TITLE
Link to Marp GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This repo (**[@marp-team/marp][marp]**) is an entrance to Marp family, and place
 ### Community
 
 - [Reflection in Qt and Beyond](https://github.com/tomisaacson/reflection-in-Qt) by [@tomisaacson](https://github.com/tomisaacson)
+- [Marp GitHub Pages Action](https://alexsci.com/test-marp-action) by [@ralexander-phi](https://github.com/ralexander-phi)
 
 <!-- - [Slide title](https://example.com/) by [@username](https://github.com/username) -->
 


### PR DESCRIPTION
Hey all!

I was working on a tool to help deploy a Marp presentation to GitHub pages using a GitHub Action.

This has a few nice benefits:

- Manage your presentation in GitHub, just like code
- Automated deployment of a presentation to free GitHub Pages hosting
- A Marp presentation showing how to get started

If there's interest I think this is a good place to add the link.

Thanks!