### PR TITLE
Relax resolutions for CVE-2020-7598

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "prettier": "^1.19.1"
   },
   "resolutions": {
-    "**/mkdirp/minimist": "^0.2.1",
     "**/optimist/minimist": "^0.2.1"
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@emotion/core": "^10.0.28",
-    "@marp-team/marp-core": "^1.0.1",
+    "@marp-team/marp-core": "^1.1.0",
     "@static/charge": "^1.7.0",
     "cross-env": "^7.0.2",
     "github-slugger": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,21 +1646,21 @@
     write-file-atomic "^2.3.0"
 
 "@marp-team/marp-core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-1.0.1.tgz#abc62bd6392734c7198590be3c190dc1a8075abd"
-  integrity sha512-lTt+qhkcMXuOgXZShV8FnMz66J+2bSUgXgtAZ3XtUMeEHZcinWhgOrBGzzmX59uvjR6UgwbYOJPJiESxNgObwg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@marp-team/marp-core/-/marp-core-1.1.0.tgz#d78f799855af0fe864a20cdcd1e6d712ba14a7b2"
+  integrity sha512-hmyhPhpVOiR2IutsQg74vU3jKfkIt/jyT/Ll+wQPyqRk6qOYxGv4yEDwKdZDnBWvVrq/UZmCMREQOaWVviMANw==
   dependencies:
-    "@marp-team/marpit" "^1.5.0"
+    "@marp-team/marpit" "^1.5.1"
     "@marp-team/marpit-svg-polyfill" "^1.2.0"
     emoji-regex "^8.0.0"
-    highlight.js "^9.17.1"
+    highlight.js "^9.18.1"
     katex "^0.11.1"
     markdown-it-emoji "^1.4.0"
-    postcss "^7.0.26"
+    postcss "^7.0.27"
     postcss-minify-params "^4.0.2"
     postcss-minify-selectors "^4.0.2"
     postcss-normalize-whitespace "^4.0.2"
-    twemoji "^12.1.4"
+    twemoji "^12.1.5"
     xss "^1.0.6"
 
 "@marp-team/marpit-svg-polyfill@^1.2.0":
@@ -1668,17 +1668,17 @@
   resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-1.2.0.tgz#3a6046e4222b6db7fc009a7d3a9ffef5cc8e60bd"
   integrity sha512-UodxNSTmuFlLAoKs32V/IWF2GEdhFS/JmqJPXEAHHb1R2EYH1VVQceZ46IaX//Up0qiBfgFRbP6EVOXD52RZrw==
 
-"@marp-team/marpit@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-1.5.0.tgz#29e5c63e640f2628040fee57bf8ffb3d273105eb"
-  integrity sha512-J2NThr5oJh0VVHfz1teX1eXnuu1duSF65DK8TfCD2r70KDJmcTwBGYVdUpfqTo3t21QFA2DZv6zjSrgEtnN1IA==
+"@marp-team/marpit@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-1.5.1.tgz#c90f85977312844259621e3ee12b86e795a4defb"
+  integrity sha512-eiMBpmvFhPJDReZ+T8haJg3FHEYEzCNMfY6RQisT9oiER2Qeg5pSQ/N5d4m6v/mvx0brkTlxQ53emtS9+aUUtA==
   dependencies:
     color-string "^1.5.3"
     js-yaml "^3.13.0"
     lodash.kebabcase "^4.1.1"
     markdown-it "^10.0.0"
-    markdown-it-front-matter "^0.1.2"
-    postcss "^7.0.26"
+    markdown-it-front-matter "^0.2.1"
+    postcss "^7.0.27"
 
 "@mdx-js/mdx@^1.5.7":
   version "1.5.7"
@@ -3445,9 +3445,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.363:
-  version "1.3.376"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.376.tgz#7cb7b5205564a06c8f8ecfbe832cbd47a1224bb1"
-  integrity sha512-cv/PYVz5szeMz192ngilmezyPNFkUjuynuL2vNdiqIrio440nfTDdc0JJU0TS2KHLSVCs9gBbt4CFqM+HcBnjw==
+  version "1.3.378"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz#18c572cbb54bf5b2769855597cdc7511c02b481f"
+  integrity sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw==
 
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
@@ -4487,7 +4487,7 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-highlight.js@^9.17.1, highlight.js@^9.18.1:
+highlight.js@^9.18.1:
   version "9.18.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
@@ -5164,11 +5164,11 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
-  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
+  integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
   dependencies:
-    minimist "^1.2.0"
+    minimist "^1.2.5"
 
 jsonfile@^3.0.0:
   version "3.0.1"
@@ -5566,10 +5566,10 @@ markdown-it-emoji@^1.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
-markdown-it-front-matter@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.1.2.tgz#e50bf56e77e6a4f5ac4ffa894d4d45ccd9896b20"
-  integrity sha1-5Qv1bnfmpPWsT/qJTU1FzNmJayA=
+markdown-it-front-matter@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.2.1.tgz#dca49a827bb3cebb0528452c1d87dff276eb28dc"
+  integrity sha512-ydUIqlKfDscRpRUTRcA3maeeUKn3Cl5EaKZSA+I/f0KOGCBurW7e+bbz59sxqkC3FA9Q2S2+t4mpkH9T0BCM6A==
 
 markdown-it@^10.0.0:
   version "10.0.0"
@@ -5758,12 +5758,12 @@ minimist-options@^4.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8, minimist@^0.2.1, minimist@~0.0.1:
+minimist@^0.2.1, minimist@~0.0.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
   integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5825,11 +5825,11 @@ mkdirp@*:
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.5"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -7624,9 +7624,9 @@ rollup-pluginutils@^2.8.1:
     estree-walker "^0.6.1"
 
 rollup@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.0.6.tgz#865d6bb15a28cff3429ea1dc57236013661cb9de"
-  integrity sha512-P42IlI6a/bxh52ed8hEXXe44LcHfep2f26OZybMJPN1TTQftibvQEl3CWeOmJrzqGbFxOA000QXDWO9WJaOQpA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.1.0.tgz#552e248e397a06b9c6db878c0564ca4ee06729c9"
+  integrity sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -8558,7 +8558,7 @@ twemoji-parser@12.1.3:
   resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.3.tgz#916c0153e77bd5f1011e7a99cbeacf52e43c9371"
   integrity sha512-ND4LZXF4X92/PFrzSgGkq6KPPg8swy/U0yRw1k/+izWRVmq1HYi3khPwV3XIB6FRudgVICAaBhJfW8e8G3HC7Q==
 
-twemoji@^12.1.4:
+twemoji@^12.1.5:
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.5.tgz#a961fb65a1afcb1f729ad7e59391f9fe969820b9"
   integrity sha512-B0PBVy5xomwb1M/WZxf/IqPZfnoIYy1skXnlHjMwLwTNfZ9ljh8VgWQktAPcJXu8080WoEh6YwQGPVhDVqvrVQ==


### PR DESCRIPTION
Relax resolutions for CVE-2020-7598 by bumping deep dependencies. `mkdirp`, many packages have depended, has bumped version to fix it.

~At the moment `yarn audit` complains to `minimist` v0.2.1, but actually it has [a backport of the same patch](https://github.com/substack/minimist/commit/d8f2cc97cc2569f2468ba06cdd0121290f630819) as v1.x.~ `optimist` has no longer maintained so I cannot expect much for patch.

**UPDATE**: npm advisory was fixed. https://www.npmjs.com/advisories/1179/versions