### PR TITLE
Disable FLoC

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   publish = "website/out"
   command = "yarn workspace @marp-team/marp-website export"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Permissions-Policy = "interest-cohort=()"


### PR DESCRIPTION
Many people hate Google's [FLoC](https://github.com/WICG/floc). Marp team should save from implicit cross-site trackings from our website visitor.

### Memo

By technical reason, Marp requires Google Chrome/Chromium to convert Marp Markdown into PDF. If you want to avoid using Chrome due to FLoC, we are providing a way to use the other flavored browser such as Brave (https://brave.com/why-brave-disables-floc/) and Vivaldi (https://vivaldi.com/blog/no-google-vivaldi-users-will-not-get-floced/)

Set the path through `CHROME_PATH` env in Marp CLI, and `Markdown > Marp: Chrome Path` setting in Marp for VS Code.