### PR TITLE
Blog article update: Opt in the new core in a VS Code extension

### DIFF
--- a/website/blog/202205-ecosystem-update.md
+++ b/website/blog/202205-ecosystem-update.md
@@ -14,9 +14,17 @@ We are so excited to introduce a stable release of **[Marp Core](https://github.
 
 <!-- more -->
 
-> I would like to mention beforehand; **Following updates are not coming to [Marp for VS Code](https://github.com/marp-team/marp-vscode) extension** at the time of publication of this article. We have recognized Marp users using GUI are including a lot of beginners and non-developers, so we think should provide enough window time for them to review breaking changes.
->
-> Currently, we are planning that v3 core would be available as [pre-release extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions), and you would become able to toggle opt in and out v3 features. ([marp-team/marp-vscode#318](https://github.com/marp-team/marp-vscode/issues/318))
+### Opt in the new core in a VS Code extension
+
+_(Updated in 2022-06-03)_
+
+In [Marp for VS Code](https://github.com/marp-team/marp-vscode) extension, this update is not yet coming to the current extension release, but you can try the new core in [a pre-released major update](https://github.com/marp-team/marp-vscode/releases/v2.0.0). Opt in the pre-released version from a **"Switch to Pre-release Version"** button in the extension detail.
+
+![Marp for VS Code v2 is available as a pre-released version](https://user-images.githubusercontent.com/3993388/171881511-f0e925a5-5b61-417f-b662-60437d1f0233.png ' ')
+
+We have recognized that Marp users who use GUI are including a lot of beginners and non-developers, so we think we should provide enough window time for them to review breaking changes.
+
+Try the pre-release extension, and prepare for the following ecosystem updates! You can easily roll back to the stable version that uses v2 core while the new extension is shipping as pre-release.
 
 # Marp Core v3
 

--- a/website/pages/_app.tsx
+++ b/website/pages/_app.tsx
@@ -8,6 +8,7 @@ import 'simplebar/dist/simplebar.min.css'
 import 'swiper/css/bundle'
 import 'css/index.css'
 
+// NProgress
 const translating = () => {
   NProgress.start()
   document.documentElement.classList.add('translating')
@@ -26,6 +27,42 @@ Router.events.on('routeChangeComplete', translated)
 Router.events.on('routeChangeError', translated)
 
 NProgress.configure({ showSpinner: false, trickleSpeed: 350 })
+
+// Make resilience from manipulating DOM by Google translator
+// https://github.com/facebook/react/issues/11538
+if (typeof Node === 'function' && Node.prototype) {
+  const { removeChild, insertBefore } = Node.prototype
+
+  Node.prototype.removeChild = function <T extends Node>(child: T): T {
+    if (child.parentNode !== this) {
+      if (console) {
+        console.error(
+          'Cannot remove a child from a different parent',
+          child,
+          this
+        )
+      }
+      return child
+    }
+    return removeChild.call(this, child) as T
+  }
+  Node.prototype.insertBefore = function <T extends Node>(
+    newNode: T,
+    referenceNode: Node | null
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (console) {
+        console.error(
+          'Cannot insert before a reference node from a different parent',
+          referenceNode,
+          this
+        )
+      }
+      return newNode
+    }
+    return insertBefore.call(this, newNode, referenceNode) as T
+  }
+}
 
 const App = ({ Component, pageProps }) => (
   <FontFaceProvider>


### PR DESCRIPTION
Update for https://marp.app/blog/202205-ecosystem-update: Describe how to opt in the new core in a VS Code extension.